### PR TITLE
Fix 32bit problems

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,14 @@ environment:
       PYTHON_VERSION: "3.6.2"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.4"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.2"
+      PYTHON_ARCH: "32"
+
 install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""

--- a/pyfastnoisesimd/wrapper.cpp
+++ b/pyfastnoisesimd/wrapper.cpp
@@ -564,15 +564,17 @@ PyFNS_FillNoiseSet(FNSObject *self, PyObject *args)
     // Fill an existing empty array, used for multi-threaded operation
     // PyObject* noiseObj;
     float* noisePtr;
+    long long noisePtr_val;
     int xStart, yStart, zStart;
     int dims[3] = {0, 0, 0};
     float scaleMod = 1.0;
     const char *format = "Liiiiii|f";
 
-    if (!PyArg_ParseTuple(args, format, &noisePtr, &zStart, &yStart, &xStart, &dims[0], &dims[1], &dims[2], &scaleMod))
+    if (!PyArg_ParseTuple(args, format, &noisePtr_val, &zStart, &yStart, &xStart, &dims[0], &dims[1], &dims[2], &scaleMod))
     {
         return NULL;
     }
+    noisePtr = (float *)noisePtr_val;
     // noisePtr = (float *)PyArray_GETPTR3((PyArrayObject *)noiseObj, 0, 0, 0);
 
     
@@ -592,11 +594,16 @@ PyFNS_NoiseFromCoords(FNSObject *self, PyObject *args)
     FastNoiseVectorSet vector;
     int size, offset;
     float *noisePtr, *xPtr, *yPtr, *zPtr;
+    long long noisePtr_val, xPtr_val, yPtr_val, zPtr_val;
 
-    if (!PyArg_ParseTuple(args, "LLLLii", &noisePtr, &zPtr, &yPtr, &xPtr, &size, &offset))
+    if (!PyArg_ParseTuple(args, "LLLLii", &noisePtr_val, &zPtr_val, &yPtr_val, &xPtr_val, &size, &offset))
     {
         return NULL;
     }
+    noisePtr = (float *)noisePtr_val;
+    xPtr = (float *)xPtr_val;
+    yPtr = (float *)yPtr_val;
+    zPtr = (float *)zPtr_val;
 
     Py_BEGIN_ALLOW_THREADS // Release GIL
     vector.size = size;


### PR DESCRIPTION
Because all files are now builtin to FastNoiseSIMD, this should now compile. However, the tests were still broken due to some trickery with pointers.

A `long long` is bigger than a pointer on 32-bit systems, and thus the values after it in `PyArg_ParseTuple` are filled with zeros (since the values are little-endian.)